### PR TITLE
Rule / Rule Config read remote values correctly

### DIFF
--- a/auth0/resource_auth0_rule.go
+++ b/auth0/resource_auth0_rule.go
@@ -35,6 +35,7 @@ func newRule() *schema.Resource {
 			"order": {
 				Type:     schema.TypeInt,
 				Optional: true,
+				Computed: true,
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
@@ -51,7 +52,7 @@ func createRule(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.SetId(c.ID)
-	return nil
+	return readRule(d, m)
 }
 
 func readRule(d *schema.ResourceData, m interface{}) error {
@@ -60,7 +61,10 @@ func readRule(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.SetId(c.ID)
+	d.Set("name", c.Name)
+	d.Set("script", c.Script)
+	d.Set("order", c.Order)
+	d.Set("enabled", c.Enabled)
 	return nil
 }
 
@@ -71,7 +75,7 @@ func updateRule(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return readRule(d, m)
 }
 
 func deleteRule(d *schema.ResourceData, m interface{}) error {

--- a/auth0/resource_auth0_rule_config.go
+++ b/auth0/resource_auth0_rule_config.go
@@ -38,7 +38,7 @@ func createRuleConfig(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 	d.SetId(r.Key)
-	return nil
+	return readRuleConfig(d, m)
 }
 
 func readRuleConfig(d *schema.ResourceData, m interface{}) error {

--- a/auth0/resource_auth0_rule_config.go
+++ b/auth0/resource_auth0_rule_config.go
@@ -47,7 +47,7 @@ func readRuleConfig(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.SetId(r.Key)
+	d.Set("key", r.Key)
 	return nil
 }
 
@@ -59,7 +59,7 @@ func updateRuleConfig(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	return readRuleConfig(d, m)
 }
 
 func deleteRuleConfig(d *schema.ResourceData, m interface{}) error {

--- a/auth0/resource_auth0_rule_config_test.go
+++ b/auth0/resource_auth0_rule_config_test.go
@@ -1,0 +1,36 @@
+package auth0
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccRuleConfig(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccRuleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_rule_config.foo", "id", "foo"),
+					resource.TestCheckResourceAttr("auth0_rule_config.foo", "key", "foo"),
+					resource.TestCheckResourceAttr("auth0_rule_config.foo", "value", "bar"),
+				),
+			},
+		},
+	})
+}
+
+const testAccRuleConfig = `
+provider "auth0" {}
+
+resource "auth0_rule_config" "foo" {
+  key = "foo"
+  value = "bar"
+}
+`


### PR DESCRIPTION
With this PR we can cross Rules and Rules Config from yieldr/terraform-provider-auth0/issues/7 