### PR TITLE
Changing name or strategy forces new resource

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -21,6 +21,7 @@ func newConnection() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"strategy": {
 				Type:     schema.TypeString,
@@ -41,6 +42,7 @@ func newConnection() *schema.Resource {
 					"waad", "weibo", "windowslive", "wordpress", "yahoo",
 					"yammer", "yandex",
 				}, true),
+				ForceNew: true,
 			},
 			"options": {
 				Type:     schema.TypeList,
@@ -168,6 +170,8 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 
 func updateConnection(d *schema.ResourceData, m interface{}) error {
 	c := buildConnection(d)
+	c.Strategy = ""
+	c.Name = ""
 	api := m.(*management.Management)
 	err := api.Connection.Update(d.Id(), c)
 	if err != nil {
@@ -194,22 +198,23 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		vL := v.([]interface{})
 		for _, v := range vL {
 
-			options := v.(map[string]interface{})
+			if options, ok := v.(map[string]interface{}); ok {
 
-			c.Options = &management.ConnectionOptions{
-				Validation:             options["validation"].(map[string]interface{}),
-				PasswordPolicy:         options["password_policy"].(string),
-				PasswordHistory:        options["password_history"].(map[string]interface{}),
-				PasswordNoPersonalInfo: options["password_no_personal_info"].(map[string]interface{}),
-				PasswordDictionary:     options["password_dictionary"].(map[string]interface{}),
-				APIEnableUsers:         options["api_enable_users"].(bool),
-				BasicProfile:           options["basic_profile"].(bool),
-				ExtAdmin:               options["ext_admin"].(bool),
-				ExtIsSuspended:         options["ext_is_suspended"].(bool),
-				ExtAgreedTerms:         options["ext_agreed_terms"].(bool),
-				ExtGroups:              options["ext_groups"].(bool),
-				ExtAssignedPlans:       options["ext_assigned_plans"].(bool),
-				ExtProfile:             options["ext_profile"].(bool),
+				c.Options = &management.ConnectionOptions{
+					Validation:             options["validation"].(map[string]interface{}),
+					PasswordPolicy:         options["password_policy"].(string),
+					PasswordHistory:        options["password_history"].(map[string]interface{}),
+					PasswordNoPersonalInfo: options["password_no_personal_info"].(map[string]interface{}),
+					PasswordDictionary:     options["password_dictionary"].(map[string]interface{}),
+					APIEnableUsers:         options["api_enable_users"].(bool),
+					BasicProfile:           options["basic_profile"].(bool),
+					ExtAdmin:               options["ext_admin"].(bool),
+					ExtIsSuspended:         options["ext_is_suspended"].(bool),
+					ExtAgreedTerms:         options["ext_agreed_terms"].(bool),
+					ExtGroups:              options["ext_groups"].(bool),
+					ExtAssignedPlans:       options["ext_assigned_plans"].(bool),
+					ExtProfile:             options["ext_profile"].(bool),
+				}
 			}
 		}
 	}

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -220,24 +220,25 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 
 			if options, ok := v.(map[string]interface{}); ok {
 
-			c.Options = &management.ConnectionOptions{
-        Validation:                   options["validation"].(map[string]interface{}),
-        PasswordPolicy:               options["password_policy"].(string),
-        PasswordHistory:              options["password_history"].(map[string]interface{}),
-        PasswordNoPersonalInfo:       options["password_no_personal_info"].(map[string]interface{}),
-        PasswordDictionary:           options["password_dictionary"].(map[string]interface{}),
-        APIEnableUsers:               options["api_enable_users"].(bool),
-        BasicProfile:                 options["basic_profile"].(bool),
-        ExtAdmin:                     options["ext_admin"].(bool),
-        ExtIsSuspended:               options["ext_is_suspended"].(bool),
-        ExtAgreedTerms:               options["ext_agreed_terms"].(bool),
-        ExtGroups:                    options["ext_groups"].(bool),
-        ExtAssignedPlans:             options["ext_assigned_plans"].(bool),
-        ExtProfile:                   options["ext_profile"].(bool),
-        EnabledDatabaseCustomization: options["enabled_database_customization"].(bool),
-        BruteForceProtection:         options["brute_force_protection"].(bool),
-        ImportMode:                   options["import_mode"].(bool),
-        DisableSignup:                options["disable_signup"].(bool),
+				c.Options = &management.ConnectionOptions{
+					Validation:                   options["validation"].(map[string]interface{}),
+					PasswordPolicy:               options["password_policy"].(string),
+					PasswordHistory:              options["password_history"].(map[string]interface{}),
+					PasswordNoPersonalInfo:       options["password_no_personal_info"].(map[string]interface{}),
+					PasswordDictionary:           options["password_dictionary"].(map[string]interface{}),
+					APIEnableUsers:               options["api_enable_users"].(bool),
+					BasicProfile:                 options["basic_profile"].(bool),
+					ExtAdmin:                     options["ext_admin"].(bool),
+					ExtIsSuspended:               options["ext_is_suspended"].(bool),
+					ExtAgreedTerms:               options["ext_agreed_terms"].(bool),
+					ExtGroups:                    options["ext_groups"].(bool),
+					ExtAssignedPlans:             options["ext_assigned_plans"].(bool),
+					ExtProfile:                   options["ext_profile"].(bool),
+					EnabledDatabaseCustomization: options["enabled_database_customization"].(bool),
+					BruteForceProtection:         options["brute_force_protection"].(bool),
+					ImportMode:                   options["import_mode"].(bool),
+					DisableSignup:                options["disable_signup"].(bool),
+				}
 			}
 		}
 	}

--- a/auth0/resource_auth0_custom_domain_test.go
+++ b/auth0/resource_auth0_custom_domain_test.go
@@ -17,7 +17,7 @@ func TestAccCustomDomain(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCustomDomain,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "domain", "auth.example.com"),
+					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "domain", "auth.example-app.com"),
 					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "type", "auth0_managed_certs"),
 					resource.TestCheckResourceAttr("auth0_custom_domain.my_custom_domain", "status", "pending_verification"),
 				),
@@ -30,7 +30,7 @@ const testAccCustomDomain = `
 provider "auth0" {}
 
 resource "auth0_custom_domain" "my_custom_domain" {
-  domain = "auth.example.com"
+  domain = "auth.example-app.com"
   type = "auth0_managed_certs"
   verification_method = "txt"
 }


### PR DESCRIPTION
This PR fixes #24 where name and strategy were being sent when an update was performed. We ignore them now and to update these properties a new resource needs to be created.