### PR TITLE
remove brute_force_protection default - only works for database conne…

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -118,7 +118,6 @@ func newConnection() *schema.Resource {
 						"brute_force_protection": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  true,
 						},
 						"import_mode": {
 							Type:     schema.TypeBool,


### PR DESCRIPTION
The option `brute_force_protection` is only valid for database connections and does not work with any other type.