### PR TITLE
[WIP] Add (currently failing) integration test for ad connection strategy

### DIFF
--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -45,3 +45,31 @@ resource "auth0_connection" "my_connection" {
 	}
 }
 `
+
+
+func TestAccAdConnection(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAdConnectionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_ad_connection", "name", "Acceptance-Test-Ad-Connection"),
+					resource.TestCheckResourceAttr("auth0_connection.my_ad_connection", "strategy", "ad"),
+				),
+			},
+		},
+	})
+}
+
+const testAccAdConnectionConfig = `
+provider "auth0" {}
+
+resource "auth0_connection" "my_ad_connection" {
+	name = "Acceptance-Test-Ad-Connection"
+	strategy = "ad"
+}
+`


### PR DESCRIPTION
Do not merge in current state.

Added a quick test that illustrates the current behaviour with a vanilla ad connection strategy.

This results in a fail:

```
...
    --- FAIL: TestAccAdConnection (1.64s)
        testing.go:518: Step 0 error: After applying this step, the plan was not empty:
                
                DIFF:
                
                UPDATE: auth0_connection.my_ad_connection
                  options.#:                        "1" => "0"
                  options.0.brute_force_protection: "false" => "true"
                
                STATE:
                
                auth0_connection.my_ad_connection:
                  ID = con_XQEUZQX8P2AOfkRe
                  provider = provider.auth0
                  enabled_clients.# = 0
                  name = Acceptance-Test-Ad-Connection
                  options.# = 1
                  options.0.api_enable_users = false
                  options.0.basic_profile = false
                  options.0.brute_force_protection = false
                  options.0.disable_signup = false
                  options.0.enabled_database_customization = false
                  options.0.ext_admin = false
                  options.0.ext_agreed_terms = false
                  options.0.ext_assigned_plans = false
                  options.0.ext_groups = false
                  options.0.ext_is_suspended = false
                  options.0.ext_profile = false
                  options.0.import_mode = false
                  options.0.password_dictionary.% = 0
                  options.0.password_history.% = 0
                  options.0.password_no_personal_info.% = 0
                  options.0.password_policy = 
                  options.0.validation.% = 0
                  realms.# = 1
                  realms.0 = Acceptance-Test-Ad-Connection
                  strategy = ad
```