### PR TITLE
improve support for addons

### DIFF
--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -36,7 +36,7 @@ resource "auth0_client" "my_client" {
   oidc_conformant = false
   callbacks = [ "https://example.com/callback" ]
   allowed_origins = [ "https://example.com" ]
-  grant_types = [ "authorization_code", "http://auth0.com/oauth/grant-type/password-realm", "implicit", "password", "refresh_token" ] 
+  grant_types = [ "authorization_code", "http://auth0.com/oauth/grant-type/password-realm", "implicit", "password", "refresh_token" ]
   allowed_logout_urls = [ "https://example.com" ]
   web_origins = [ "https://example.com" ]
   jwt_configuration = {
@@ -45,6 +45,14 @@ resource "auth0_client" "my_client" {
     alg = "RS256"
     scopes = {
     	foo = "bar"
+    }
+  }
+  addons = {
+    firebase = {
+      client_email = "wer"
+      lifetime_in_seconds = 1
+      private_key = "wer"
+      private_key_id = "qwreerwerwe"
     }
   }
   mobile = {

--- a/example/client/main.tf
+++ b/example/client/main.tf
@@ -9,11 +9,22 @@ resource "auth0_client" "my_app_client" {
   callbacks       = ["https://example.com/callback"]
   allowed_origins = ["https://example.com"]
   web_origins     = ["https://example.com"]
-  grant_types =  [ "authorization_code", "http://auth0.com/oauth/grant-type/password-realm", "implicit", "password", "refresh_token" ]  
+  grant_types =  [ "authorization_code", "http://auth0.com/oauth/grant-type/password-realm", "implicit", "password", "refresh_token" ]
 
   jwt_configuration = {
     lifetime_in_seconds = 120
     secret_encoded      = true
     alg                 = "RS256"
+  }
+
+  custom_login_page_on = "true"
+
+  addons = {
+    firebase = {
+      client_email = "wer"
+      lifetime_in_seconds = 1
+      private_key = "wer"
+      private_key_id = "qwreerwerwe"
+    }
   }
 }


### PR DESCRIPTION
This should fix #31 by making client addons usable.

My approach here was to make it available in as simple way as possible without getting into the specifics of each addon and their validation requirements.

Instead we rely on a `map[string]interface{}` to map keys to and leave the validation to users. Eventually though we might want to properly define schema's for each of the addons, making them more robust and user friendly.