### PR TITLE
add custom_scripts and configuration

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -132,6 +132,16 @@ func newConnection() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
+						"custom_scripts": {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Optional: true,
+						},
+						"configuration": {
+							Type:     schema.TypeMap,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Optional: true,
+						},
 					},
 				},
 			},
@@ -189,6 +199,8 @@ func readConnection(d *schema.ResourceData, m interface{}) error {
 			"import_mode":                    c.Options.ImportMode,
 			"disable_signup":                 c.Options.DisableSignup,
 			"requires_username":              c.Options.RequiresUsername,
+			"custom_scripts":                 c.Options.CustomScripts,
+			"configuration":                  c.Options.Configuration,
 		},
 	})
 
@@ -252,6 +264,8 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 					ImportMode:                   options["import_mode"].(bool),
 					DisableSignup:                options["disable_signup"].(bool),
 					RequiresUsername:             options["requires_username"].(bool),
+					CustomScripts:                options["custom_scripts"].(map[string]interface{}),
+					Configuration:                options["configuration"].(map[string]interface{}),
 				}
 			}
 		}

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -141,6 +141,12 @@ func newConnection() *schema.Resource {
 							Type:     schema.TypeMap,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Optional: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if old != "" {
+									return true
+								}
+								return new == old
+							},
 						},
 					},
 				},

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -25,6 +25,8 @@ func TestAccConnection(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.import_mode", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.disable_signup", "true"),
 					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.requires_username", "true"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "options.0.custom_scripts.get_user", "myFunction"),
+					resource.TestCheckResourceAttrSet("auth0_connection.my_connection", "options.0.configuration.foo"),
 				),
 			},
 		},
@@ -44,6 +46,12 @@ resource "auth0_connection" "my_connection" {
 		import_mode = true
 		disable_signup = true
 		requires_username = true
+		custom_scripts = {
+			get_user = "myFunction"
+		}
+		configuration = {
+			foo = "bar"
+		}
 	}
 }
 `


### PR DESCRIPTION
The `configuration` values are not idempotents. So we have this error :
```
Step 0 error: After applying this step, the plan was not empty
		DIFF:
		
		UPDATE: auth0_connection.my_connection
		  options.0.configuration.foo: "2.0$6df00cdfae84850348500c66bba4e149$55a001dccf409fd01117b1149f7e608e$7ea6872cefcafadaf6f17d17cb4b42fc35155575ebb58bd2d79c15d53841b1dc" => "bar"

```

I saw some documentation to adapt the diff: https://www.terraform.io/docs/extend/schemas/schema-behaviors.html#diffsuppressfunc
But I'm not sure this is the right solution.

Can you help me ?