### PR TITLE
Add debug property to provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -352,8 +352,8 @@
 [[projects]]
   name = "github.com/yieldr/go-auth0"
   packages = ["management"]
-  revision = "eb3eff6156cf8d7f85f488ce162986524bc00adf"
-  version = "v0.2.1"
+  revision = "14dfd41b76960a85c3885ea215ffa72a79f643cc"
+  version = "v0.2.2"
 
 [[projects]]
   branch = "master"
@@ -494,6 +494,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "aaf6e850012d04e0300322e6d5bff27b4a221c5565ae341d4723f422004b765b"
+  inputs-digest = "e7a3d9e27a460d2d26d36f586bad10c3c140de93192cd10c95b226b19f7f3aa3"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/yieldr/go-auth0"
-  version = "v0.2.1"
+  version = "v0.2.2"
 
 [prune]
   go-tests = true

--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -1,6 +1,8 @@
 package auth0
 
 import (
+	"os"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/yieldr/go-auth0/management"
 )
@@ -23,6 +25,18 @@ func Provider() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("AUTH0_CLIENT_SECRET", nil),
 			},
+			"debug": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				DefaultFunc: func() (interface{}, error) {
+					v := os.Getenv("AUTH0_DEBUG")
+					if v == "" {
+						return false, nil
+					}
+
+					return v == "1" || v == "true" || v == "on", nil
+				},
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"auth0_client":          newClient(),
@@ -44,6 +58,7 @@ func configure(data *schema.ResourceData) (interface{}, error) {
 	domain := data.Get("domain").(string)
 	id := data.Get("client_id").(string)
 	secret := data.Get("client_secret").(string)
+	debug := data.Get("debug").(bool)
 
-	return management.New(domain, id, secret)
+	return management.New(domain, id, secret, management.WithDebug(debug))
 }

--- a/auth0/provider_test.go
+++ b/auth0/provider_test.go
@@ -1,9 +1,65 @@
 package auth0
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestProvider(t *testing.T) {
 	if err := Provider().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_debugDefaults(t *testing.T) {
+	testCases := map[string]struct {
+		envSet   bool
+		envValue string
+		expected bool
+	}{
+		`should be true when AUTH0_DEBUG environment variable is set to "1"`: {
+			envSet:   true,
+			envValue: "1",
+			expected: true,
+		},
+		`should be true when AUTH0_DEBUG environment variable is set to "true"`: {
+			envSet:   true,
+			envValue: "true",
+			expected: true,
+		},
+		`should be true when AUTH0_DEBUG environment variable is set to "on"`: {
+			envSet:   true,
+			envValue: "on",
+			expected: true,
+		},
+		`should be false when AUTH0_DEBUG environment variable is set to "false"`: {
+			envSet:   true,
+			envValue: "false",
+			expected: false,
+		},
+		"should be false if no AUTH0_DEBUG environment variable is defined": {
+			envSet:   false,
+			expected: false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			os.Unsetenv("AUTH0_DEBUG")
+			if tc.envSet {
+				os.Setenv("AUTH0_DEBUG", tc.envValue)
+			}
+
+			p := Provider()
+
+			debug, err := p.Schema["debug"].DefaultValue()
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if debug.(bool) != tc.expected {
+				t.Fatalf("Expected debug to be %v, but got %v", tc.expected, debug)
+			}
+		})
 	}
 }

--- a/vendor/github.com/yieldr/go-auth0/management/connection.go
+++ b/vendor/github.com/yieldr/go-auth0/management/connection.go
@@ -71,6 +71,7 @@ type ConnectionOptions struct {
 	BruteForceProtection         bool `json:"brute_force_protection,omitempty"`
 	ImportMode                   bool `json:"import_mode,omitempty"`
 	DisableSignup                bool `json:"disable_signup,omitempty"`
+	RequiresUsername             bool `json:"requires_username,omitempty"`
 
 	// Options for adding parameters in the request to the upstream IdP.
 	UpstreamParams interface{} `json:"upstream_params,omitempty"`
@@ -84,6 +85,12 @@ type ConnectionOptions struct {
 	WaadCommonEndpoint bool          `json:"waad_common_endpoint,omitempty"`
 	AppID              string        `json:"app_id,omitempty"`
 	AppDomain          string        `json:"app_domain,omitempty"`
+
+	// Scripts for the connction
+	// Allowed keys are: "get_user", "login", "create", "verify", "change_password" or "delete".
+	CustomScripts map[string]interface{} `json:"custom_scripts,omitempty"`
+	// configuration variables that can be used in custom scripts
+	Configuration map[string]interface{} `json:"configuration,omitempty"`
 }
 
 type ConnectionManager struct {

--- a/vendor/github.com/yieldr/go-auth0/management/management.go
+++ b/vendor/github.com/yieldr/go-auth0/management/management.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -66,7 +67,6 @@ type Token struct {
 // Management API v2.
 //
 type Management struct {
-
 	// Client manages Auth0 Client (also known as Application) resources.
 	Client *ClientManager
 
@@ -262,7 +262,7 @@ func (m *Management) delete(uri string) error {
 func (m *Management) dump(req *http.Request, res *http.Response) {
 	b1, _ := httputil.DumpRequest(req, true)
 	b2, _ := httputil.DumpResponse(res, true)
-	fmt.Printf("%s\n%s\b\n", b1, b2)
+	log.Printf("%s\n%s\b\n", b1, b2)
 }
 
 type apiOption func(*Management)


### PR DESCRIPTION
Cannot check if this actually works right now, because we need to have updated vendored **go-auth0** with this https://github.com/yieldr/go-auth0/pull/11.

So this is a WIP until vendors are updated.