### PR TITLE
Fix rule name regexp

### DIFF
--- a/auth0/resource_auth0_rule.go
+++ b/auth0/resource_auth0_rule.go
@@ -8,6 +8,8 @@ import (
 	"github.com/yieldr/go-auth0/management"
 )
 
+var ruleNameRegexp = regexp.MustCompile("^[^\\s-][\\w -]+[^\\s-]$")
+
 func newRule() *schema.Resource {
 	return &schema.Resource{
 
@@ -24,7 +26,7 @@ func newRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[^\\s-][\\w -]+[^\\s-]$"),
+					ruleNameRegexp,
 					"Can only contain alphanumeric characters, spaces and '-'. "+
 						"Can neither start nor end with '-' or spaces."),
 			},

--- a/auth0/resource_auth0_rule.go
+++ b/auth0/resource_auth0_rule.go
@@ -24,7 +24,7 @@ func newRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: validation.StringMatch(
-					regexp.MustCompile("^[^\\s-][\\w-]+[^\\s-]$"),
+					regexp.MustCompile("^[^\\s-][\\w -]+[^\\s-]$"),
 					"Can only contain alphanumeric characters, spaces and '-'. "+
 						"Can neither start nor end with '-' or spaces."),
 			},

--- a/auth0/resource_auth0_rule_test.go
+++ b/auth0/resource_auth0_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/validation"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -35,3 +36,46 @@ resource "auth0_rule" "my_rule" {
   enabled = true
 }
 `
+
+func TestRuleNameRegexp(t *testing.T) {
+	testCases := []struct {
+		name  string
+		valid bool
+	}{
+		{
+			name:  "my-rule-1",
+			valid: true,
+		},
+		{
+			name:  "rule 2 name with spaces",
+			valid: true,
+		},
+		{
+			name:  " rule with a space prefix",
+			valid: false,
+		},
+		{
+			name:  "rule with a space suffix ",
+			valid: false,
+		},
+		{
+			name:  " ", // rule with only one space,
+			valid: false,
+		},
+		{
+			name:  "   ", // rule with only three spaces,
+			valid: false,
+		},
+	}
+
+	vf := validation.StringMatch(ruleNameRegexp, "invalid name")
+	for _, tc := range testCases {
+		_, errs := vf(tc.name, "name")
+		if errs != nil && tc.valid {
+			t.Fatalf("Expected %q to be valid, but got validation errors %v", tc.name, errs)
+		}
+		if errs == nil && !tc.valid {
+			t.Fatalf("Expected %q to be invalid, but got no validation errors.", tc.name)
+		}
+	}
+}


### PR DESCRIPTION
Current regexp for rule name does not allow spaces, but it should.
This commit fixes the issue.