### PR TITLE
Improve support for password history

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -67,9 +67,21 @@ func newConnection() *schema.Resource {
 							}, false),
 						},
 						"password_history": {
-							Type:     schema.TypeMap,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"enable": {
+										Type:     schema.TypeBool,
+										Optional: true,
+									},
+									"size": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
+								},
+							},
 						},
 						"password_no_personal_info": {
 							Type:     schema.TypeMap,
@@ -246,10 +258,11 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 		for _, v := range vL {
 
 			if options, ok := v.(map[string]interface{}); ok {
+
 				c.Options = &management.ConnectionOptions{
 					Validation:                   options["validation"].(map[string]interface{}),
 					PasswordPolicy:               auth0.String(options["password_policy"].(string)),
-					PasswordHistory:              options["password_history"].(map[string]interface{}),
+					PasswordHistory:              buildConnectionPasswordHistory(options["password_history"].([]interface{})),
 					PasswordNoPersonalInfo:       options["password_no_personal_info"].(map[string]interface{}),
 					PasswordDictionary:           options["password_dictionary"].(map[string]interface{}),
 					APIEnableUsers:               auth0.Bool(options["api_enable_users"].(bool)),
@@ -273,4 +286,20 @@ func buildConnection(d *schema.ResourceData) *management.Connection {
 	}
 
 	return c
+}
+
+func buildConnectionPasswordHistory(v []interface{}) map[string]interface{} {
+	for _, vI := range v {
+		if phc, ok := vI.(map[string]interface{}); ok {
+			passwordHistory := make(map[string]interface{})
+			if enable, ok := phc["enable"]; ok {
+				passwordHistory["enable"] = enable.(bool)
+			}
+			if size, ok := phc["size"]; ok {
+				passwordHistory["size"] = size.(int)
+			}
+			return passwordHistory
+		}
+	}
+	return nil
 }

--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -50,7 +50,6 @@ func newConnection() *schema.Resource {
 			"options": {
 				Type:     schema.TypeList,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -41,6 +41,10 @@ resource "auth0_connection" "my_connection" {
 	strategy = "auth0"
 	options = {
 		password_policy = "fair"
+		password_history = {
+			enable = "true"
+			size = "5"
+		}
 		enabled_database_customization = false
 		brute_force_protection = true
 		import_mode = true
@@ -55,7 +59,6 @@ resource "auth0_connection" "my_connection" {
 	}
 }
 `
-
 
 func TestAccAdConnection(t *testing.T) {
 

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -60,7 +60,7 @@ resource "auth0_connection" "my_connection" {
 }
 `
 
-func TestAccAdConnection(t *testing.T) {
+func TestAccConnectionAd(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		Providers: map[string]terraform.ResourceProvider{
@@ -68,7 +68,7 @@ func TestAccAdConnection(t *testing.T) {
 		},
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAdConnectionConfig,
+				Config: testAccConnectionAdConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("auth0_connection.my_ad_connection", "name", "Acceptance-Test-Ad-Connection"),
 					resource.TestCheckResourceAttr("auth0_connection.my_ad_connection", "strategy", "ad"),
@@ -78,7 +78,7 @@ func TestAccAdConnection(t *testing.T) {
 	})
 }
 
-const testAccAdConnectionConfig = `
+const testAccConnectionAdConfig = `
 provider "auth0" {}
 
 resource "auth0_connection" "my_ad_connection" {

--- a/example/connection/main.tf
+++ b/example/connection/main.tf
@@ -5,6 +5,10 @@ resource "auth0_connection" "my_connection" {
   strategy = "auth0"
   options = {
     password_policy = "excellent"
+    password_history = {
+      enable = "true"
+      size = "3"
+    }
     brute_force_protection = "true"
     enabled_database_customization = "true"
     custom_scripts = {


### PR DESCRIPTION
Fixes #40. Defined schema for `password_history` to properly support setting the `enable` and `size` fields.