### PR TITLE
Fix CustomDomain crash when already verified

### DIFF
--- a/auth0/resource_auth0_custom_domain.go
+++ b/auth0/resource_auth0_custom_domain.go
@@ -83,9 +83,13 @@ func readCustomDomain(d *schema.ResourceData, m interface{}) error {
 	d.Set("type", c.Type)
 	d.Set("primary", c.Primary)
 	d.Set("status", c.Status)
-	d.Set("verification", []map[string]interface{}{
-		{"methods": c.Verification.Methods},
-	})
+
+	if c.Verification != nil {
+		d.Set("verification", []map[string]interface{}{
+			{"methods": c.Verification.Methods},
+		})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This fixes #55 where creating a custom domain would crash if it were already verified. Auth0 doesn't include a verification object if it has already been verified, causing this provider to crash.