### PR TITLE
Fix the error for managing client metadata

### DIFF
--- a/auth0/resource_auth0_client.go
+++ b/auth0/resource_auth0_client.go
@@ -575,9 +575,12 @@ func buildClient(d *schema.ResourceData) *management.Client {
 		}
 	})
 
-	List(d, "client_metadata").First(func(v interface{}) {
-		c.ClientMetadata = v.(map[string]string)
-	})
+	if v, ok := d.GetOk("client_metadata"); ok {
+		c.ClientMetadata = make(map[string]string)
+		for key, value := range v.(map[string]interface{}) {
+			c.ClientMetadata[key] = (value.(string))
+		}
+	}
 
 	List(d, "mobile").First(func(v interface{}) {
 

--- a/auth0/resource_auth0_client_test.go
+++ b/auth0/resource_auth0_client_test.go
@@ -23,6 +23,7 @@ func TestAccClient(t *testing.T) {
 					resource.TestCheckResourceAttr("auth0_client.my_client", "addons.0.samlp.0.audience", "https://example.com/saml"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "addons.0.samlp.0.map_identities", "false"),
 					resource.TestCheckResourceAttr("auth0_client.my_client", "addons.0.samlp.0.name_identifier_format", "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"),
+					resource.TestCheckResourceAttr("auth0_client.my_client", "client_metadata.foo", "zoo"),
 				),
 			},
 		},
@@ -51,6 +52,9 @@ resource "auth0_client" "my_client" {
     scopes = {
     	foo = "bar"
     }
+  }
+  client_metadata = {
+    foo = "zoo"
   }
   addons = {
     firebase = {


### PR DESCRIPTION
When client_metadata is applied the provider panics with the following error:

`
panic: interface conversion: interface {} is map[string]interface {}, not []interface {}
2018-12-05T14:39:36.374+0700 [DEBUG] plugin.terraform-provider-auth0:
2018-12-05T14:39:36.374+0700 [DEBUG] plugin.terraform-provider-auth0: goroutine 211 [running]:
2018-12-05T14:39:36.374+0700 [DEBUG] plugin.terraform-provider-auth0: github.com/yieldr/terraform-provider-auth0/auth0.List(0x1b85480, 0xc0001ea230, 0x1a21df9, 0xf, 0xc00045ed80)
2018-12-05T14:39:36.374+0700 [DEBUG] plugin.terraform-provider-auth0:   /Users/anton.mednonogov/prj/go/src/github.com/yieldr/terraform-provider-auth0/auth0/resource_data.go:115 +0x146
`
I am a new person in Go, so if you have suggestions how to improve the PR, I'd be more than happy :)