### PR TITLE
fix: mark rule-config value as sensitive

### DIFF
--- a/auth0/resource_auth0_rule_config.go
+++ b/auth0/resource_auth0_rule_config.go
@@ -25,6 +25,7 @@ func newRuleConfig() *schema.Resource {
 			"value": {
 				Type:     schema.TypeString,
 				Required: true,
+				Sensitive: true,
 			},
 		},
 	}


### PR DESCRIPTION
By spec, auth0 rule configuration variables are obfuscated to allow for secrets to be stored in them. This correspondingly marks the TF value as sensitive.