### PR TITLE
resource_auth0_tenant

### DIFF
--- a/auth0/provider.go
+++ b/auth0/provider.go
@@ -49,6 +49,7 @@ func Provider() *schema.Provider {
 			"auth0_email":           newEmail(),
 			"auth0_email_template":  newEmailTemplate(),
 			"auth0_user":            newUser(),
+			"auth0_tenant":          newTenant(),
 		},
 		ConfigureFunc: configure,
 	}

--- a/auth0/resource_auth0_tenant.go
+++ b/auth0/resource_auth0_tenant.go
@@ -81,39 +81,40 @@ func newTenant() *schema.Resource {
 				},
 			},
 			"flags": {
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"change_pwd_flow_v1": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  false,
+							Computed: true,
 						},
 						"enable_client_connections": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  true,
+							Computed: true,
 						},
 						"enable_apis_section": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  true,
+							Computed: true,
 						},
 						"enable_pipeline2": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  true,
+							Computed: true,
 						},
 						"enable_dynamic_client_registration": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  false,
+							Computed: true,
 						},
 						"enable_custom_domain_in_emails": {
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  false,
+							Computed: true,
 						},
 					},
 				},
@@ -142,6 +143,11 @@ func newTenant() *schema.Resource {
 			"session_lifetime": {
 				Type:     schema.TypeInt,
 				Optional: true,
+			},
+			"sandbox_version": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}
@@ -172,6 +178,7 @@ func readTenant(d *schema.ResourceData, m interface{}) error {
 	d.Set("support_url", t.SupportURL)
 	d.Set("allowed_logout_urls", t.AllowedLogoutURLs)
 	d.Set("session_lifetime", t.SessionLifetime)
+	d.Set("sandbox_version", t.SandboxVersion)
 
 	return nil
 }
@@ -200,6 +207,7 @@ func buildTenant(d *schema.ResourceData) *management.Tenant {
 		SupportURL:        String(d, "support_url"),
 		AllowedLogoutURLs: Slice(d, "allowed_logout_urls"),
 		SessionLifetime:   Int(d, "session_lifetime"),
+		SandboxVersion:    String(d, "sandbox_version"),
 	}
 
 	List(d, "change_password").First(func(v interface{}) {
@@ -220,16 +228,17 @@ func buildTenant(d *schema.ResourceData) *management.Tenant {
 		}
 	})
 
-	m := Map(d, "flags")
-
-	t.Flags = &management.TenantFlags{
-		ChangePasswordFlowV1:            Bool(MapData(m), "change_pwd_flow_v1"),
-		EnableClientConnections:         Bool(MapData(m), "enable_client_connections"),
-		EnableAPIsSection:               Bool(MapData(m), "enable_apis_section"),
-		EnablePipeline2:                 Bool(MapData(m), "enable_pipeline2"),
-		EnableDynamicClientRegistration: Bool(MapData(m), "enable_dynamic_client_registration"),
-		EnableCustomDomainInEmails:      Bool(MapData(m), "enable_custom_domain_in_emails"),
-	}
+	List(d, "flags").First(func(v interface{}) {
+		m := v.(map[string]interface{})
+		t.Flags = &management.TenantFlags{
+			ChangePasswordFlowV1:            Bool(MapData(m), "change_pwd_flow_v1"),
+			EnableClientConnections:         Bool(MapData(m), "enable_client_connections"),
+			EnableAPIsSection:               Bool(MapData(m), "enable_apis_section"),
+			EnablePipeline2:                 Bool(MapData(m), "enable_pipeline2"),
+			EnableDynamicClientRegistration: Bool(MapData(m), "enable_dynamic_client_registration"),
+			EnableCustomDomainInEmails:      Bool(MapData(m), "enable_custom_domain_in_emails"),
+		}
+	})
 
 	return t
 }

--- a/auth0/resource_auth0_tenant.go
+++ b/auth0/resource_auth0_tenant.go
@@ -1,0 +1,235 @@
+package auth0
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/yieldr/go-auth0/management"
+)
+
+func newTenant() *schema.Resource {
+	return &schema.Resource{
+
+		Create: createTenant,
+		Read:   readTenant,
+		Update: updateTenant,
+		Delete: deleteTenant,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"change_password": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"html": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"guardian_mfa_page": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"html": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"default_audience": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"default_directory": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"error_page": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"html": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"show_log_link": {
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"url": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"flags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"change_pwd_flow_v1": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  false,
+						},
+						"enable_client_connections": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  true,
+						},
+						"enable_apis_section": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  true,
+						},
+						"enable_pipeline2": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  true,
+						},
+						"enable_dynamic_client_registration": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  false,
+						},
+						"enable_custom_domain_in_emails": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  false,
+						},
+					},
+				},
+			},
+			"friendly_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"picture_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"support_email": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"support_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"allowed_logout_urls": {
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+			},
+			"session_lifetime": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func createTenant(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+	d.SetId(api.Domain)
+	return readTenant(d, m)
+}
+
+func readTenant(d *schema.ResourceData, m interface{}) error {
+	api := m.(*management.Management)
+	t, err := api.Tenant.Read()
+	if err != nil {
+		return err
+	}
+
+	d.Set("change_password", t.ChangePassword)
+	d.Set("guardian_mfa_page", t.GuardianMFAPage)
+	d.Set("default_audience", t.DefaultAudience)
+	d.Set("default_directory", t.DefaultDirectory)
+	d.Set("error_page", t.ErrorPage)
+	d.Set("flags", t.Flags)
+	d.Set("friendly_name", t.FriendlyName)
+	d.Set("picture_url", t.PictureURL)
+	d.Set("support_email", t.SupportEmail)
+	d.Set("support_url", t.SupportURL)
+	d.Set("allowed_logout_urls", t.AllowedLogoutURLs)
+	d.Set("session_lifetime", t.SessionLifetime)
+
+	return nil
+}
+
+func updateTenant(d *schema.ResourceData, m interface{}) error {
+	t := buildTenant(d)
+	api := m.(*management.Management)
+	err := api.Tenant.Update(t)
+	if err != nil {
+		return err
+	}
+	return readTenant(d, m)
+}
+
+func deleteTenant(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+func buildTenant(d *schema.ResourceData) *management.Tenant {
+	t := &management.Tenant{
+		DefaultAudience:   String(d, "default_audience"),
+		DefaultDirectory:  String(d, "default_directory"),
+		FriendlyName:      String(d, "friendly_name"),
+		PictureURL:        String(d, "picture_url"),
+		SupportEmail:      String(d, "support_email"),
+		SupportURL:        String(d, "support_url"),
+		AllowedLogoutURLs: Slice(d, "allowed_logout_urls"),
+		SessionLifetime:   Int(d, "session_lifetime"),
+	}
+
+	List(d, "change_password").First(func(v interface{}) {
+		m := v.(map[string]interface{})
+
+		t.ChangePassword = &management.TenantChangePassword{
+			Enabled: Bool(MapData(m), "enabled"),
+			HTML:    String(MapData(m), "html"),
+		}
+	})
+
+	List(d, "guardian_mfa_page").First(func(v interface{}) {
+		m := v.(map[string]interface{})
+
+		t.GuardianMFAPage = &management.TenantGuardianMFAPage{
+			Enabled: Bool(MapData(m), "enabled"),
+			HTML:    String(MapData(m), "html"),
+		}
+	})
+
+	m := Map(d, "flags")
+
+	t.Flags = &management.TenantFlags{
+		ChangePasswordFlowV1:            Bool(MapData(m), "change_pwd_flow_v1"),
+		EnableClientConnections:         Bool(MapData(m), "enable_client_connections"),
+		EnableAPIsSection:               Bool(MapData(m), "enable_apis_section"),
+		EnablePipeline2:                 Bool(MapData(m), "enable_pipeline2"),
+		EnableDynamicClientRegistration: Bool(MapData(m), "enable_dynamic_client_registration"),
+		EnableCustomDomainInEmails:      Bool(MapData(m), "enable_custom_domain_in_emails"),
+	}
+
+	return t
+}

--- a/vendor/github.com/yieldr/go-auth0/management/management.go
+++ b/vendor/github.com/yieldr/go-auth0/management/management.go
@@ -63,7 +63,7 @@ type Management struct {
 	// Stat is used to retrieve usage statistics.
 	Stat *StatManager
 
-	domain   string
+	Domain   string
 	basePath string
 	timeout  time.Duration
 	debug    bool
@@ -76,7 +76,7 @@ type Management struct {
 func New(domain, clientID, clientSecret string, options ...apiOption) (*Management, error) {
 
 	m := &Management{
-		domain:   domain,
+		Domain:   domain,
 		basePath: "api/v2",
 		timeout:  1 * time.Minute,
 		debug:    false,
@@ -110,7 +110,7 @@ func New(domain, clientID, clientSecret string, options ...apiOption) (*Manageme
 func (m *Management) uri(path ...string) string {
 	return (&url.URL{
 		Scheme: "https",
-		Host:   m.domain,
+		Host:   m.Domain,
 		Path:   m.basePath + "/" + strings.Join(path, "/"),
 	}).String()
 }


### PR DESCRIPTION
Thank you for taking the effort in open sourcing this project. We’re using this at [DFIN](https://dfinsolutions.com) and would like to contribute functionality we’ll need: Tenant resource.

This is a WIP branch of the `resource_auth0_tenant`, so it's still missing tests but I wanted to get eyes on this sooner than later. There's still some outstanding questions and given this is my first contributing to a Terraform provider, I'm sure there's some improvements that can be made based on feedback here.

An couple of things to note:
- Auth0 doesn't provide an API to create or delete Tenants (only `GET` and `PATCH` are supported). This might go against the general idea of Terraform. However, that shouldn't stop us from being able to maintain the Tenant settings in the same codebase as other Auth0 resources.
- Auth0 Tenant endpoint only returns default values for certain properties (`flags.disable_impersonation`, `flags.enable_sso`, `flags.allow_changing_enable_sso`). However, you can't modify those values.

Here are some issues I ran into as relates to the Tenant resource:
- `id`: Given the context of the provider is a single Tenant (as defined by the `domain` property), I used the `domain` property out of `auth0.Management` struct, however, I had to make it public first.
  - Do you know of a way to get a config of the provider while in the `createTenant` method? This could avoid the need to expose `domain` in the management package.
- Missing from `yieldr/go-auth0`
  - `idle_session_lifetime`
  - `universal_login`: this is relativity new, see 
https://support.auth0.com/notifications/5c6349d4867b00000abcdacc.
- `flags`
  - Related to the above point, I went ahead and set them all to `Computed: true` since if you set them once then remove them from the Terraform file, they retain the last value they set. Is there a better way?
   - Auth0 API doesn't allow an empty `flags` property to be sent, therefore, if you set a flag, then apply, then remove the entire block, you'll get an error. Is there a way to stop Terraform from sending the `flag` property if the only change is the removal of the block? I tried something like this `if !d.HasKeyChange('flags.#')` but didn't seem to work. 

Example:

```
resource "auth0_tenant" "tenant" {
  change_password {
    enabled = true
    html = "${file("./password_reset.html")}"
  }

  guardian_mfa_page {
    enabled = true
    html = "${file("./guardian_multifactor.html")}"
  }

  flags {
    enable_client_connections = true
  }
}
```


