### PR TITLE
Fix compile instructions in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,10 +74,10 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 
 On how to develop custom terraform providers, read the [official guide](https://www.terraform.io/docs/extend/writing-custom-providers.html).
 
-To compile the provider, run `make install`. This will build the provider and install the provider binary in the `$GOPATH/bin` directory.
+To compile the provider, run `make build`. This will build the provider and install the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make install
+$ make build
 ...
 $ $GOPATH/bin/terraform-provider-auth0
 ...


### PR DESCRIPTION
Replace 'make install' by 'make build'. There is no 'install' target in the GNUMakefile