### PR TITLE
the Connection's enabled_clients attribute is not indempotent

### DIFF
--- a/auth0/resource_auth0_connection.go
+++ b/auth0/resource_auth0_connection.go
@@ -217,6 +217,19 @@ func newConnection() *schema.Resource {
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if strings.Contains(k, "#") {
+						return old == new
+					}
+
+					enabledClients := Slice(d, "enabled_clients")
+					result := false
+					for _, v := range enabledClients {
+						result = result || (v == old)
+					}
+
+					return result
+				},
 			},
 			"realms": {
 				Type:     schema.TypeList,

--- a/auth0/resource_auth0_connection_test.go
+++ b/auth0/resource_auth0_connection_test.go
@@ -131,3 +131,62 @@ resource "auth0_connection" "my_connection" {
 	}
 }
 `
+
+func TestAccConnectionWithEnbledClients(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"auth0": Provider(),
+		},
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccConnectionWithEnabledClientsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "name", "Acceptance-Test-Connection"),
+					resource.TestCheckResourceAttr("auth0_connection.my_connection", "enabled_clients.#", "4"),
+				),
+			},
+		},
+	})
+}
+
+const testAccConnectionWithEnabledClientsConfig = `
+provider "auth0" {}
+
+resource "auth0_client" "my_client_1" {
+  name = "Application - Acceptance Test 1"
+  description = "Test Applications Long Description"
+  app_type = "non_interactive"
+}
+
+resource "auth0_client" "my_client_2" {
+  name = "Application - Acceptance Test 2"
+  description = "Test Applications Long Description"
+  app_type = "non_interactive"
+}
+
+resource "auth0_client" "my_client_3" {
+  name = "Application - Acceptance Test 3"
+  description = "Test Applications Long Description"
+  app_type = "non_interactive"
+}
+
+resource "auth0_client" "my_client_4" {
+  name = "Application - Acceptance Test 4"
+  description = "Test Applications Long Description"
+  app_type = "non_interactive"
+}
+
+resource "auth0_connection" "my_connection" {
+	name = "Acceptance-Test-Connection"
+	is_domain_connection = true
+	strategy = "auth0"
+	enabled_clients = [
+    "${auth0_client.my_client_1.id}",
+    "${auth0_client.my_client_2.id}",
+    "${auth0_client.my_client_3.id}",
+    "${auth0_client.my_client_4.id}",
+  ]
+
+}
+`


### PR DESCRIPTION
Hello

When I create a Connection with enabled_clients, the order of the ids is not always the same.
I have an error like that:
```
	testing.go:527: Step 0 error: After applying this step, the plan was not empty:
		
		DIFF:
		
		UPDATE: auth0_connection.my_connection
		  enabled_clients.0: "VciGGT5jZGbIlYC3nKABabKGjFlx8pMD" => "d8Io6XgKtoUHScGqmcniX9lLHpl4CHbE"
		  enabled_clients.1: "d8Io6XgKtoUHScGqmcniX9lLHpl4CHbE" => "xUolj4m6SejtAjtP3czFiSZw3f7M7c4q"
		  enabled_clients.2: "xUolj4m6SejtAjtP3czFiSZw3f7M7c4q" => "yqncnHsP3Gane086n5s70ucEUyuVFZ0Q"
		  enabled_clients.3: "yqncnHsP3Gane086n5s70ucEUyuVFZ0Q" => "VciGGT5jZGbIlYC3nKABabKGjFlx8pMD"

```

I propose to add a DiffSuppressFunc on the attribute.
But the verification is slow (up to 6s on my computer and auth0 tenant).
Do you think of another solution ?

